### PR TITLE
add support for canonical domain exceptions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,4 +22,15 @@ Installation and usage
   enforce HTTPS.
 
 
+Configuration
+#############
+
+
+``CANONICAL_DOMAIN_EXCEPTIONS``
+Default: []
+
+A list of complete domain names such as ``'api.example.com'`` that should
+not be redirected to the canonical domain.
+
+
 .. include:: ../CHANGELOG.rst


### PR DESCRIPTION
Allow to set `CANONICAL_DOMAIN_EXCEPTIONS` list of complete domains on which is no redirection to the canonical domain.

This replaces #2 with simpler design of domain exceptions.

Note: I am still a bit fond of the regexp matches. It would make the use-case of this option much wider - e.g. excluding whole domains or certain subdomain on all domains. I cloud add secondary settings `CANONICAL_DOMAIN_EXCEPTIONS_REGEX` for that if there is interest.