### PR TITLE
change CANONICAL_DOMAIN_EXCEPTION->CANONICAL_DOMAIN_EXEMPT, respect SECURE_REDIRECT_EXEMPT

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,17 +20,23 @@ Installation and usage
 - Set ``SECURE_SSL_HOST = 'example.com'`` in your settings.
 - Optionally set ``SECURE_SSL_REDIRECT = True`` if you want to
   enforce HTTPS.
+- ``django-canonical-domain`` also respects ``SECURE_REDIRECT_EXEMPT`` settings.
+  In the case path matches the regex the url will be redirected to ``SECURE_SSL_HOST``,
+  but the protocol will not be changed.
+
 
 
 Configuration
 #############
 
 
-``CANONICAL_DOMAIN_EXCEPTIONS``
+``CANONICAL_DOMAIN_EXEMPT``
+
 Default: []
 
-A list of complete domain names such as ``'api.example.com'`` that should
-not be redirected to the canonical domain.
+A list of complete domain regex matches such, e.g. ``CANONICAL_DOMAIN_EXEMPT = [r'^api.example.com$', ...]``
+
+When the host matches any of these, the middleware will not redirect to the canonical domain.
 
 
 .. include:: ../CHANGELOG.rst

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -2,4 +2,7 @@ from django.http import HttpResponse
 from django.urls import path
 
 
-urlpatterns = [path("", lambda request: HttpResponse("Hello world"))]
+urlpatterns = [
+    path("", lambda request: HttpResponse("Hello world")),
+    path("no-ssl", lambda request: HttpResponse("Hello world")),
+]


### PR DESCRIPTION
@matthiask Here are the requested changes.
I realized, that in order to respect `CANONICAL_DOMAIN_EXEMPT` we should redirect but not change http(s) in case the host is not matching.

I also renamed the variable `secure` to `secure_redirect` to make it clear among other similarly named variables.